### PR TITLE
Fix debug mode can't load dylib from work dir

### DIFF
--- a/vendor/github.com/ying32/dylib/dylib_posix.go
+++ b/vendor/github.com/ying32/dylib/dylib_posix.go
@@ -161,7 +161,10 @@ func fileExists(path string) bool {
 func (l *LazyDLL) libFullPath(name string) string {
 	if runtime.GOOS == "darwin" {
 		file, _ := exec.LookPath(os.Args[0])
-		return filepath.Dir(file) + "/" + name
+		libPath := filepath.Dir(file) + "/" + name
+		if fileExists(libPath) {
+			return libPath
+		}
 	}
 	return name
 }


### PR DESCRIPTION
修复 macOS 使用 GoLand 调试模式启动时，无法从工作目录加载动态库
原因是 GoLand 调试启动，会把 可执行文件创建到临时文件夹

```text
/private/var/folders/vc/5md5ch3s71513qk2dcn968_80000gn/T/___1go_build_gui
```

返回绝对路径前判断文件是否存在，如不存在，则返回 lib名字，后续 dlopen 时，会从当前工作目录搜索加载
此时只要配置好调试配置的工作目录，即可正确加载调试